### PR TITLE
Added optional Express server for local self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,37 +40,21 @@ Unfortunately I can only get the creation date for a video from the API, not the
 You can run this project as a standalone server using Node.js.
 
 ---
+```
+1. Clone the repo:
 
-1. Build the app:
+git clone https://github.com/multitools-ap-mvp/twitch-vod-sync/tree/master
+
+2. Build the app:
 
 npm run build
 
-2. Start the server:
+3. Start the server:
 
 npm run serve
 
-3. Open:
+4. Open:
 
 http://localhost:3000
-
+```
 ---
-
-Why this is needed
-
-The app uses "%PUBLIC_URL%", which is only processed during build.
-
-Serving the "public/" folder directly will cause errors like:
-
-```
-URIError: Failed to decode param '%PUBLIC_URL%/...'
-```
-
-## Setup 
-
-```
-git clone https://github.com/multitools-ap-mvp/twitch-vod-sync/tree/master
-npm install
-npm run build
-npm run serve
-```
-

--- a/README.md
+++ b/README.md
@@ -40,21 +40,21 @@ Unfortunately I can only get the creation date for a video from the API, not the
 You can run this project as a standalone server using Node.js.
 
 ---
-```
 1. Clone the repo:
-
+```
 git clone https://github.com/remram44/twitch-vod-sync.git
+```
 
 2. Build the app:
-
+```
 npm run build
-
+```
 3. Start the server:
-
+```
 npm run serve
-
+```
 4. Open:
-
+```
 http://localhost:3000
 ```
 ---

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ FAQ
 ### Why do I need to give access to my Twitch account?
 
 Unfortunately I can only get the creation date for a video from the API, not the embed system, and the API needs authorization. Note that I am requesting no permissions on your account, I just query the video API on your behalf. This is also a static web app so I am not collecting the access token (it stays in your browser).
+
+---
+
+# Selfhost
+
+---
+
+
+

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ You can run this project as a standalone server using Node.js.
 ```
 git clone https://github.com/remram44/twitch-vod-sync.git
 ```
+Install dependencies
+```
+npm install
+```
 
 2. Build the app:
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can run this project as a standalone server using Node.js.
 ```
 1. Clone the repo:
 
-git clone https://github.com/multitools-ap-mvp/twitch-vod-sync/tree/master
+git clone https://github.com/remram44/twitch-vod-sync.git
 
 2. Build the app:
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,48 @@ FAQ
 
 Unfortunately I can only get the creation date for a video from the API, not the embed system, and the API needs authorization. Note that I am requesting no permissions on your account, I just query the video API on your behalf. This is also a static web app so I am not collecting the access token (it stays in your browser).
 
----
 
 # Selfhost
 
 ---
 
 
+🖥️ Self-hosting with Node/Express (optional)
+
+You can run this project as a standalone server using Node.js.
+
+---
+
+1. Build the app:
+
+npm run build
+
+2. Start the server:
+
+npm run serve
+
+3. Open:
+
+http://localhost:3000
+
+---
+
+Why this is needed
+
+The app uses "%PUBLIC_URL%", which is only processed during build.
+
+Serving the "public/" folder directly will cause errors like:
+
+```
+URIError: Failed to decode param '%PUBLIC_URL%/...'
+```
+
+## Setup 
+
+```
+git clone https://github.com/multitools-ap-mvp/twitch-vod-sync/tree/master
+npm install
+npm run build
+npm run serve
+```
 

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
+    "express": "^4.22.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "serve": "node server.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "check": "gts check",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static files from build
+app.use(express.static(path.join(__dirname, 'build')));
+
+// SPA fallback (important for React routing)
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'build', 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
**Added option for local/self-hosting with express.**  

**Changes:** 

Added Express 4.22.1 to Dependencies.
Added "serve" line to package.json + A simple server.js file to run with Node. 

This is Purely additive to improve usability.
No breaking changes, The WebApp stay the same.
Improves developer onboarding and adds a Github favorit, Selfhost! 

Included SPA fallback.

Added the install notes to Readme.
Might be improved but basically the user now have the option to selfhost if the App is offline or to keep the user data In house or whatever.

---
How to use: 
--- 

✔ Development
```
Bash
npm install
npm start
```

✔ Production
```
Bash
npm run build
```

✔ Self-hosting
```
Bash
npm run build
npm run serve
```